### PR TITLE
Feature/11 travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: python
+
+python:
+    - "3.6"
+    - "3.7"
+
+env:
+    global:
+        - PIPENV_VENV_IN_PROJECT=1
+        - PIPENV_IGNORE_VIRTUALENVS=1
+
+install:
+    - pip install pipenv
+    - pipenv install --dev --three
+
+script:
+    - pipenv run pycodestyle --show-source .
+    - pipenv run pydocstyle .
+
+test:
+    - pipenv run python -m unittest discover
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,10 @@ install:
     - pipenv install --dev --three
 
 script:
-    - pipenv run pycodestyle . --ignore ./.venv
-    - pipenv run pydocstyle . --ignore ./.venv
+    - mkdir ~/.config
+    - cp ./setup.cfg ~/.config/pycodestyle
+    - pipenv run pycodestyle .
+    - pipenv run pydocstyle .
 
 test:
     - pipenv run python -m unittest discover

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,12 @@ env:
         - PIPENV_IGNORE_VIRTUALENVS=1
 
 install:
-    - export PIPENV_CACHE_DIR='/home'
     - pip install pipenv
     - pipenv install --dev --three
 
 script:
-    - pipenv run pycodestyle .
-    - pipenv run pydocstyle .
+    - pipenv run pycodestyle . --ignore ./.venv
+    - pipenv run pydocstyle . --ignore ./.venv
 
 test:
     - pipenv run python -m unittest discover

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
     - "3.6"
-    - "3.7"
 
 env:
     global:
@@ -14,7 +13,6 @@ install:
     - pipenv install --dev --three
 
 script:
-    - mkdir ~/.config
     - cp ./setup.cfg ~/.config/pycodestyle
     - pipenv run pycodestyle .
     - pipenv run pydocstyle .

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,10 @@ env:
 install:
     - pip install pipenv
     - pipenv install --dev --three
+    - cp ./setup.cfg ~/.config/pycodestyle
 
 script:
-    - cp ./setup.cfg ~/.config/pycodestyle
     - pipenv run pycodestyle .
     - pipenv run pydocstyle .
-
-test:
     - pipenv run python -m unittest discover
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,12 @@ env:
         - PIPENV_IGNORE_VIRTUALENVS=1
 
 install:
+    - export PIPENV_CACHE_DIR='/home'
     - pip install pipenv
     - pipenv install --dev --three
 
 script:
-    - pipenv run pycodestyle --show-source .
+    - pipenv run pycodestyle .
     - pipenv run pydocstyle .
 
 test:

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,8 @@ name = "pypi"
 [packages]
 
 [dev-packages]
+pycodestyle = "*"
+pydocstyle = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4e55147db217bb4120f6e68cb8cad7bc37011457441ce0eb9d97308315625834"
+            "sha256": "82499177c9ca69620cdab4ac530ad7ea2c654428b2ad1f33deb3635db07a2c69"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,5 +16,37 @@
         ]
     },
     "default": {},
-    "develop": {}
+    "develop": {
+        "pycodestyle": {
+            "hashes": [
+                "sha256:cbc619d09254895b0d12c2c691e237b2e91e9b2ecf5e84c26b35400f93dcfb83",
+                "sha256:cbfca99bd594a10f674d0cd97a3d802a1fdef635d4361e1a2658de47ed261e3a"
+            ],
+            "index": "pypi",
+            "version": "==2.4.0"
+        },
+        "pydocstyle": {
+            "hashes": [
+                "sha256:08a870edc94508264ed90510db466c6357c7192e0e866561d740624a8fc7d90c",
+                "sha256:4d5bcde961107873bae621f3d580c3e35a426d3687ffc6f8fb356f6628da5a97",
+                "sha256:af9fcccb303899b83bec82dc9a1d56c60fc369973223a5e80c3dfa9bdf984405"
+            ],
+            "index": "pypi",
+            "version": "==2.1.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            ],
+            "version": "==1.11.0"
+        },
+        "snowballstemmer": {
+            "hashes": [
+                "sha256:919f26a68b2c17a7634da993d91339e288964f93c274f1343e3bbbe2096e1128",
+                "sha256:9f3bcd3c401c3e862ec0ebe6d2c069ebc012ce142cce209c098ccb5b09136e89"
+            ],
+            "version": "==1.2.1"
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# CoFiSync
+[![Build Status](https://travis-ci.org/jaume-gasa/CoFiSync.svg?branch=master)](https://travis-ci.org/jaume-gasa/CoFiSync)
+# CoFiSync 
 >Awesome continuous file synchronization made with Pyhon 🐍
 
 
@@ -14,6 +15,12 @@
 3. Commit your changes (`git commit -am 'Add some fooBar'`)
 4. Push to the branch (`git push origin feature/fooBar`)
 5. Create a new Pull Request
+
+#### Branch naming
+
+When creating a new branch name it like this:
+
+`feature/{Task number in taiga.io}-{Name_in_taiga.io}`
 
 ## Task log
 ---

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[pycodestyle]
+max-line-length = 120
+statistics = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [pycodestyle]
 max-line-length = 120
-statistics = True
+exclude = ./.venv

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test module."""

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,11 @@
+"""Test just to check travis integration when real code appears this should be deleted"""
+from unittest import TestCase
+
+
+class BaseTest(TestCase):
+    """Test to check everything is ok with travis integration"""
+
+    def test_maths(self):
+        """Check maths still work at the most basic level"""
+
+        self.assertEqual(2, 1 + 1)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,11 +1,11 @@
-"""Test just to check travis integration when real code appears this should be deleted"""
+"""Test just to check travis integration when real code appears this should be deleted."""
 from unittest import TestCase
 
 
 class BaseTest(TestCase):
-    """Test to check everything is ok with travis integration"""
+    """Test to check everything is ok with travis integration."""
 
     def test_maths(self):
-        """Check maths still work at the most basic level"""
+        """Check maths still work at the most basic level."""
 
         self.assertEqual(2, 1 + 1)


### PR DESCRIPTION
Added travis-ci support checking (also the cool badge):

- Pycodestyle
- Pydocstyle
- Al tests that can be discovered by "python -m unittest discover" (https://docs.python.org/3/library/unittest.html#unittest-test-discovery)

Seems like they don't have support for python 3.7 yet.
I also sneaked the branch naming in the README.md because I don't thing it deservest a full feature for a little edit.